### PR TITLE
Added a user snippet to block pings in tag arguments

### DIFF
--- a/TagScript.code-snippets
+++ b/TagScript.code-snippets
@@ -36,12 +36,6 @@
 			"{=(hins):3600}",
 			"{=(${2:output}):{strf({m:trunc({unix}+({hins}*{offset}))}):${3:%-I:%M %p}}}"]
 	},
-	
-	"Block pings in tag arguments": {
-		"prefix": "noping",
-		"body": ["{break({in(<@):{args}}==true):Please don't try to ping people with this command.}"],
-		"description": "Blocks users from pinging any roles or other users using tag arguments"
-	}
 
 	"Blank variable (conditional blocks)": {
 		"prefix": "blank",
@@ -105,6 +99,12 @@
 	"Set a variable to uppercase easily": {
 		"prefix": "uppervar",
 		"body": "{=(${1:u1}):{upper:${2:variable}}"
+	},
+
+	"Block pings in tag arguments": {
+		"prefix": "noping",
+		"body": ["{break({in(<@):{args}}==true):Please don't try to ping people with this command.}"],
+		"description": "Blocks users from pinging any roles or other users using tag arguments"
 	},
 
 	/* ===== TAGSCRIPT ADVANCED USAGE BLOCKS (FROM DOCS) ===== */

--- a/TagScript.code-snippets
+++ b/TagScript.code-snippets
@@ -103,8 +103,9 @@
 
 	"Block pings in tag arguments": {
 		"prefix": "noping",
-		"body": ["{break({in(<@):{args}}==true):Please don't try to ping people with this command.}"],
-		"description": "Blocks users from pinging any roles or other users using tag arguments"
+		"body": ["{=():}
+{{or({in(<@&):{args}}==true|{in(@here):{args}}==true|{in(@everyone):{args}}==true|{replace(!,):{in(<@{target(id)}>):{args}}}==true):blacklist:{server(id)}}}"],
+		"description": "Blocks users from pinging any roles or users using tag arguments"
 	},
 
 	/* ===== TAGSCRIPT ADVANCED USAGE BLOCKS (FROM DOCS) ===== */

--- a/TagScript.code-snippets
+++ b/TagScript.code-snippets
@@ -36,6 +36,12 @@
 			"{=(hins):3600}",
 			"{=(${2:output}):{strf({m:trunc({unix}+({hins}*{offset}))}):${3:%-I:%M %p}}}"]
 	},
+	
+	"Block pings in tag arguments": {
+		"prefix": "noping",
+		"body": ["{break({in(<@):{args}}==true):Please don't try to ping people with this command.}"],
+		"description": "Blocks users from pinging any roles or other users using tag arguments"
+	}
 
 	"Blank variable (conditional blocks)": {
 		"prefix": "blank",


### PR DESCRIPTION
I just had multiple people spam pings with bot commands in my server recently and I realized I had some Carl tags that could also be affected. I came up with this line that prevents people from pinging others with Carl-bot using tag arguments. 